### PR TITLE
Call initialize method, if not exists then call init. Many nodejs module...

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -49,8 +49,15 @@
 			create : function ()
 			{
 				var instance = Object.create(this);
-				if (typeof instance.init == "function") {
-					instance.init.apply(instance, arguments);
+				/**
+				 * Try to execute #initialize() or #init() method if one of them exists.
+				 */
+				if (typeof instance.initialize == "function") {
+					instance.initialize.apply(instance, arguments);
+				}else{
+					if (typeof instance.init == "function") {
+						instance.init.apply(instance, arguments);
+					}
 				}
 				return instance;
 			},


### PR DESCRIPTION
... already use init as primary method, it will cause errors.
