### PR TITLE
Only wrap functions that are calling ._super

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -43,7 +43,7 @@
 			 */
 			mixin: function (prop, obj) {
 				var self = obj || this,
-					fnTest = /xyz/.test(function () {}) ? /\b_super\b/ : /.*/,
+					fnTest = /\b_super\b/,
 					_super = Object.getPrototypeOf(self) || self.prototype,
 					_old;
 


### PR DESCRIPTION
This pull request fixes a big performance issue wrapping methods every time instead of just the ones that are calling `._super`.
