### PR TITLE
Only copy function keys

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -39,15 +39,15 @@
     };
 
     if (isFunction) {
-      Object.getOwnPropertyNames(old).forEach(function (name) {
+      Object.keys(old).forEach(function (name) {
         newMethod[name] = old[name];
       });
-    }
 
-    if (isFunction && HAS_SYMBOLS) {
-      Object.getOwnPropertySymbols(old).forEach(function (name) {
-        newMethod[name] = old[name];
-      });
+      if (HAS_SYMBOLS) {
+        Object.getOwnPropertySymbols(old).forEach(function (name) {
+          newMethod[name] = old[name];
+        });
+      }
     }
 
     return newMethod;


### PR DESCRIPTION
This is a follow up for #23. Only enumerable keys should be copied otherwise we will get errors on non-writable properties in some environments (see #25).

Closes #25